### PR TITLE
Async Listen

### DIFF
--- a/listen_test.go
+++ b/listen_test.go
@@ -394,12 +394,15 @@ func TestListenAsync(t *testing.T) {
 		pendingSet sync.Map // Set of which streams are pending
 		// All streams are connected
 		connectedWg sync.WaitGroup
+		// All listener goroutines are stopped
+		listenerWg sync.WaitGroup
 	)
+	listenerWg.Add(parallelCount)
 	pendingWg.Add(parallelCount)
 	connectedWg.Add(parallelCount)
 	for i := 0; i < parallelCount; i++ {
 		go func() {
-
+			defer listenerWg.Done()
 			for {
 				_, _, err := ln.Accept(func(req ConnRequest) ConnType {
 					// Only call Done() if we're the first request for this stream
@@ -430,4 +433,5 @@ func TestListenAsync(t *testing.T) {
 	// Wait for all streams to be connected
 	connectedWg.Wait()
 	ln.Close()
+	listenerWg.Wait()
 }

--- a/listen_test.go
+++ b/listen_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"net"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -381,4 +382,52 @@ func TestListenHSV5(t *testing.T) {
 	pc.WriteTo(data.Bytes(), p.Header().Addr)
 
 	pc.Close()
+}
+
+func TestListenAsync(t *testing.T) {
+	const parallelCount = 2
+	ln, err := Listen("srt", "127.0.0.1:6003", DefaultConfig())
+	require.NoError(t, err)
+	var (
+		// All streams are pending
+		pendingWg  sync.WaitGroup
+		pendingSet sync.Map // Set of which streams are pending
+		// All streams are connected
+		connectedWg sync.WaitGroup
+	)
+	pendingWg.Add(parallelCount)
+	connectedWg.Add(parallelCount)
+	for i := 0; i < parallelCount; i++ {
+		go func() {
+
+			for {
+				_, _, err := ln.Accept(func(req ConnRequest) ConnType {
+					// Only call Done() if we're the first request for this stream
+					if _, ok := pendingSet.Swap(req.StreamId(), struct{}{}); !ok {
+						pendingWg.Done()
+					}
+					// Wait for all streams to be pending Before returning
+					pendingWg.Wait()
+					return PUBLISH
+				})
+				if err == ErrListenerClosed {
+					return
+				}
+				require.NoError(t, err)
+			}
+		}()
+
+		go func(streamId string) {
+			config := DefaultConfig()
+			config.StreamId = streamId
+			conn, err := Dial("srt", "127.0.0.1:6003", config)
+			require.NoError(t, err)
+			connectedWg.Done()
+			conn.Close()
+		}(strconv.Itoa(i))
+	}
+
+	// Wait for all streams to be connected
+	connectedWg.Wait()
+	ln.Close()
 }


### PR DESCRIPTION
It is not currently possible to safely run multiple goroutines that call `Accept` which means  that we are limited in scale by how fast that Accept function returns. There are two issues that prevent using parallel `Accept`s
1. Shutdown behavior. Currently the library depends on a single message sent over the error channel to exit out of the `Accept` function, subsequent calls will block indefinitely waiting for a message
2. Re-use of the `config` attribute on listener. Currently the library only uses the config attribute on listener to store state about the request which means that a) 1 stream can change behavior for other streams b) There's a data race preventing parallel reads. We can fix this by creating a copy of the base configuration & attach that copy to the request