### PR TITLE
Handle dup handshakes

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -215,6 +215,10 @@ func newSRTConn(config srtConnConfig) *srtConn {
 		c.onShutdown = func(socketId uint32) {}
 	}
 
+	if c.logger == nil {
+		c.logger = NewLogger(nil)
+	}
+
 	c.nextACKNumber = circular.New(1, packet.MAX_TIMESTAMP)
 	c.ackNumbers = make(map[uint32]time.Time)
 

--- a/listen.go
+++ b/listen.go
@@ -347,6 +347,9 @@ func (ln *listener) Accept(acceptFn AcceptFunc) (Conn, ConnType, error) {
 		ln.lock.Lock()
 		if _, ok := ln.handshakes[handshakeKey{request.addr, request.socketId}]; ok {
 			ln.lock.Unlock()
+			ln.log("listen", func() string {
+				return fmt.Sprintf("received duplicate handshake packet, addr: %s, socketId: %d", request.addr.String(), request.socketId)
+			})
 			break
 		}
 		ln.handshakes[handshakeKey{request.addr, request.socketId}] = true

--- a/listen_test.go
+++ b/listen_test.go
@@ -394,12 +394,15 @@ func TestListenAsync(t *testing.T) {
 		pendingSet sync.Map // Set of which streams are pending
 		// All streams are connected
 		connectedWg sync.WaitGroup
+		// All listener goroutines are stopped
+		listenerWg sync.WaitGroup
 	)
+	listenerWg.Add(parallelCount)
 	pendingWg.Add(parallelCount)
 	connectedWg.Add(parallelCount)
 	for i := 0; i < parallelCount; i++ {
 		go func() {
-
+			defer listenerWg.Done()
 			for {
 				_, _, err := ln.Accept(func(req ConnRequest) ConnType {
 					// Only call Done() if we're the first request for this stream
@@ -430,4 +433,5 @@ func TestListenAsync(t *testing.T) {
 	// Wait for all streams to be connected
 	connectedWg.Wait()
 	ln.Close()
+	listenerWg.Wait()
 }

--- a/listen_test.go
+++ b/listen_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"net"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -381,4 +382,52 @@ func TestListenHSV5(t *testing.T) {
 	pc.WriteTo(data.Bytes(), p.Header().Addr)
 
 	pc.Close()
+}
+
+func TestListenAsync(t *testing.T) {
+	const parallelCount = 2
+	ln, err := Listen("srt", "127.0.0.1:6003", DefaultConfig())
+	require.NoError(t, err)
+	var (
+		// All streams are pending
+		pendingWg  sync.WaitGroup
+		pendingSet sync.Map // Set of which streams are pending
+		// All streams are connected
+		connectedWg sync.WaitGroup
+	)
+	pendingWg.Add(parallelCount)
+	connectedWg.Add(parallelCount)
+	for i := 0; i < parallelCount; i++ {
+		go func() {
+
+			for {
+				_, _, err := ln.Accept(func(req ConnRequest) ConnType {
+					// Only call Done() if we're the first request for this stream
+					if _, ok := pendingSet.Swap(req.StreamId(), struct{}{}); !ok {
+						pendingWg.Done()
+					}
+					// Wait for all streams to be pending Before returning
+					pendingWg.Wait()
+					return PUBLISH
+				})
+				if err == ErrListenerClosed {
+					return
+				}
+				require.NoError(t, err)
+			}
+		}()
+
+		go func(streamId string) {
+			config := DefaultConfig()
+			config.StreamId = streamId
+			conn, err := Dial("srt", "127.0.0.1:6003", config)
+			require.NoError(t, err)
+			connectedWg.Done()
+			conn.Close()
+		}(strconv.Itoa(i))
+	}
+
+	// Wait for all streams to be connected
+	connectedWg.Wait()
+	ln.Close()
 }


### PR DESCRIPTION
Maintains a map of connections that are in the handshake process. This prevents the `acceptFn` from being called multiple times in the case of a duplicate control packet. This change will cause the listener to just drop the duplicate packets, and any handshake control packet that comes along with the same peer address and socket id combo.