### PR TITLE
Ensure no socket id collisions, and verify sender IPs

### DIFF
--- a/config.go
+++ b/config.go
@@ -169,6 +169,9 @@ type Config struct {
 
 	// An implementation of the Logger interface
 	Logger Logger
+
+	// if a new IP starts sending data on an existing socket id, allow it
+	AllowPeerIpChange bool
 }
 
 // DefaultConfig is the default configuration for a SRT connection
@@ -209,6 +212,7 @@ var defaultConfig Config = Config{
 	TooLatePacketDrop:     true,
 	TransmissionType:      "live",
 	TSBPDMode:             true,
+	AllowPeerIpChange:     false,
 }
 
 // DefaultConfig returns the default configuration for Dial and Listen.

--- a/listen.go
+++ b/listen.go
@@ -584,10 +584,12 @@ func (ln *listener) reader(ctx context.Context) {
 				break
 			}
 
-			if p.Header().Addr.String() != conn.RemoteAddr().String() {
-				// ignore the packet, it's not from the expected peer
-				// https://haivision.github.io/srt-rfc/draft-sharabayko-srt.html#name-security-considerations
-				break
+			if !ln.config.AllowPeerIpChange {
+				if p.Header().Addr.String() != conn.RemoteAddr().String() {
+					// ignore the packet, it's not from the expected peer
+					// https://haivision.github.io/srt-rfc/draft-sharabayko-srt.html#name-security-considerations
+					break
+				}
 			}
 
 			conn.push(p)


### PR DESCRIPTION
https://github.com/muxinc/video-ingest-and-processing-team/issues/120

Use `cyrpto/rand` to generate socket IDs now. Also verifying we haven't somehow landed on that socket id before, rejecting the connection if we have.

We're also now verifying the sender ip + port, which attempts to mitigate an attacker from trying to send on an existing socket id. Using a `cyrpto/rand` should make the socket id difficult to guess as well.