### PR TITLE
Clean up and rebase our patches against upstream

### DIFF
--- a/config.go
+++ b/config.go
@@ -169,6 +169,9 @@ type Config struct {
 
 	// An implementation of the Logger interface
 	Logger Logger
+
+	// if a new IP starts sending data on an existing socket id, allow it
+	AllowPeerIpChange bool
 }
 
 // DefaultConfig is the default configuration for a SRT connection
@@ -209,6 +212,7 @@ var defaultConfig Config = Config{
 	TooLatePacketDrop:     true,
 	TransmissionType:      "live",
 	TSBPDMode:             true,
+	AllowPeerIpChange:     false,
 }
 
 // DefaultConfig returns the default configuration for Dial and Listen.

--- a/conn_request.go
+++ b/conn_request.go
@@ -397,7 +397,7 @@ func (req *connRequest) Accept() (Conn, error) {
 	// Create a new socket ID
 	socketId, err := req.generateSocketId()
 	if err != nil {
-		return nil, fmt.Errorf("could not generate socket id")
+		return nil, fmt.Errorf("could not generate socket id: %w", err)
 	}
 
 	// Select the largest TSBPD delay advertised by the caller, but at least 120ms

--- a/listen.go
+++ b/listen.go
@@ -407,6 +407,14 @@ func (ln *listener) reader(ctx context.Context) {
 				break
 			}
 
+			if !ln.config.AllowPeerIpChange {
+				if p.Header().Addr.String() != conn.RemoteAddr().String() {
+					// ignore the packet, it's not from the expected peer
+					// https://haivision.github.io/srt-rfc/draft-sharabayko-srt.html#name-security-considerations
+					break
+				}
+			}
+
 			conn.push(p)
 		}
 	}


### PR DESCRIPTION
This includes 3 patches
 - drop packets from wrong source address
 - generate socket ids randomly (completely rewritten)
 - expose config to app layer on handshake
 
