### PR TITLE
Reject handshakes from established connections

### DIFF
--- a/listen_test.go
+++ b/listen_test.go
@@ -692,10 +692,10 @@ func TestListenDiscardRepeatedHandshakes(t *testing.T) {
 		onlyRequest.Reject(REJ_CLOSE)
 	}()
 
+	conn, err := net.Dial("udp", "127.0.0.1:6003")
+	require.NoError(t, err)
+	defer conn.Close()
 	for i := 0; i < 4; i++ {
-		conn, err := net.Dial("udp", "127.0.0.1:6003")
-		require.NoError(t, err)
-		defer conn.Close()
 
 		// send induction request
 		p := packet.NewPacket(conn.RemoteAddr())
@@ -770,6 +770,128 @@ func TestListenDiscardRepeatedHandshakes(t *testing.T) {
 		require.NoError(t, err)
 		_, err = conn.Write(buf.Bytes())
 		require.NoError(t, err)
+	}
+
+	<-singleReqReceived
+	ln.Close()
+}
+
+func TestListenDiscardRepeatedHandshakesAfterConnect(t *testing.T) {
+	ln, err := Listen("srt", "127.0.0.1:6003", DefaultConfig())
+	require.NoError(t, err)
+
+	listenDone := make(chan struct{})
+	defer func() { <-listenDone }()
+
+	singleReqReceived := make(chan struct{})
+
+	go func() {
+		defer close(listenDone)
+
+		for {
+			req, err := ln.Accept2()
+			if err != nil {
+				break
+			}
+
+			close(singleReqReceived)
+
+			req.Accept()
+		}
+
+	}()
+
+	conn, err := net.Dial("udp", "127.0.0.1:6003")
+	require.NoError(t, err)
+	defer conn.Close()
+	for i := 0; i < 4; i++ {
+
+		// send induction request
+		p := packet.NewPacket(conn.RemoteAddr())
+		p.Header().IsControlPacket = true
+		p.Header().ControlType = packet.CTRLTYPE_HANDSHAKE
+		p.Header().SubType = 0
+		p.Header().TypeSpecific = 0
+		p.Header().Timestamp = 0
+		p.Header().DestinationSocketId = 0
+		sendcif := &packet.CIFHandshake{
+			IsRequest:                   true,
+			Version:                     4,
+			EncryptionField:             0,
+			ExtensionField:              2,
+			InitialPacketSequenceNumber: circular.New(10000, packet.MAX_SEQUENCENUMBER),
+			MaxTransmissionUnitSize:     MAX_MSS_SIZE,
+			MaxFlowWindowSize:           25600,
+			HandshakeType:               packet.HSTYPE_INDUCTION,
+			SRTSocketId:                 55555,
+			SynCookie:                   0,
+		}
+		sendcif.PeerIP.FromNetAddr(conn.LocalAddr())
+		p.MarshalCIF(sendcif)
+		var buf bytes.Buffer
+		err = p.Marshal(&buf)
+		require.NoError(t, err)
+		_, err = conn.Write(buf.Bytes())
+		require.NoError(t, err)
+
+		// read induction response
+		inbuf := make([]byte, 1024)
+		n, err := conn.Read(inbuf)
+		require.NoError(t, err)
+		p, err = packet.NewPacketFromData(conn.RemoteAddr(), inbuf[:n])
+		require.NoError(t, err)
+		recvcif := &packet.CIFHandshake{}
+		err = p.UnmarshalCIF(recvcif)
+		require.NoError(t, err)
+
+		// send conclusion
+		p.Header().IsControlPacket = true
+		p.Header().ControlType = packet.CTRLTYPE_HANDSHAKE
+		p.Header().SubType = 0
+		p.Header().TypeSpecific = 0
+		p.Header().Timestamp = 0
+		p.Header().DestinationSocketId = 0 // recvcif.SRTSocketId
+		sendcif.Version = 5
+		sendcif.ExtensionField = recvcif.ExtensionField
+		sendcif.HandshakeType = packet.HSTYPE_CONCLUSION
+		sendcif.SynCookie = recvcif.SynCookie
+		sendcif.HasHS = true
+		sendcif.SRTHS = &packet.CIFHandshakeExtension{
+			SRTVersion: SRT_VERSION,
+			SRTFlags: packet.CIFHandshakeExtensionFlags{
+				TSBPDSND:      true,
+				TSBPDRCV:      true,
+				CRYPT:         true, // must always set to true
+				TLPKTDROP:     true,
+				PERIODICNAK:   true,
+				REXMITFLG:     true,
+				STREAM:        false,
+				PACKET_FILTER: false,
+			},
+			RecvTSBPDDelay: uint16(120),
+			SendTSBPDDelay: uint16(120),
+		}
+		sendcif.HasSID = true
+		sendcif.StreamId = "foobar"
+		p.MarshalCIF(sendcif)
+		buf.Reset()
+		err = p.Marshal(&buf)
+		require.NoError(t, err)
+		_, err = conn.Write(buf.Bytes())
+		require.NoError(t, err)
+
+		// read conclusion response (but only for the first iteration; later
+		// ones should be ignored since we won't have a response)
+		if i == 0 {
+			inbuf = make([]byte, 1024)
+			n, err = conn.Read(inbuf)
+			require.NoError(t, err)
+			p, err = packet.NewPacketFromData(conn.RemoteAddr(), inbuf[:n])
+			require.NoError(t, err)
+			recvcif = &packet.CIFHandshake{}
+			err = p.UnmarshalCIF(recvcif)
+			require.NoError(t, err)
+		}
 	}
 
 	<-singleReqReceived


### PR DESCRIPTION
If we're mid-handshake, we use listener.connReqs to drop handshake messages that we're in the middle of handling.

However, we also want to drop handshakes that arrive _after_ we've established a connection (they were presumably sent before the peer was aware that we'd accepted the connection!).

Rather than track this separately, this extends the lifespan of entries in connReqs to include the lifespan of the actual connection, and documents it so.
